### PR TITLE
Synb.Button.js does not release internal focus property

### DIFF
--- a/src/client/echo/Sync.Button.js
+++ b/src/client/echo/Sync.Button.js
@@ -250,6 +250,7 @@ Echo.Sync.Button = Core.extend(Echo.Render.ComponentSync, {
         
     /** Processes a focus blur event. */
     _processBlur: function(e) {
+        this._focused = false;
         this.setHighlightState(false, false);
     },
     


### PR DESCRIPTION
Hi!

In current implementation of Sync.Button.js the variable _focused is never set to false - even if a blur event occurs on the button.

This causes some ugly behaviour because focus handling of echo3 and the browser doesn't match any more.

The main problem is that the renderFocus function of Sync.Button.js doesn't fire a dom event on the second time geting focus.

imho a simple solution could be just to add
this._focused = false;
to the _processBlur function of Sync.Button.js.

Attached commit will fix this bug.

See also Mantis Bug-ID: 520
http://bugs.nextapp.com/mantis/view.php?id=520

Cheers Ralf
