### PR TITLE
Fix IE9 throwing servlet error on special characters in Textfields

### DIFF
--- a/src/client/corejs/Core.Web.js
+++ b/src/client/corejs/Core.Web.js
@@ -130,6 +130,10 @@ Core.Web.DOM = {
                         "application/xml");
             } else {
                 dom = document.implementation.createDocument(namespaceUri, qualifiedName, null);
+                try {
+                    // Advises the IE9 to sent posts back in UTF-8 as expected. See http://echo.nextapp.com/site/node/6658
+                    dom.charset = "utf-8";
+                } catch(e) {} // ignore potential errors. It works without all other browsers.
             }
             if (!dom.documentElement) {
                 dom.appendChild(dom.createElement(qualifiedName));

--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/resource/RemoteClient.js
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/resource/RemoteClient.js
@@ -539,7 +539,7 @@ Echo.RemoteClient = Core.extend(Echo.Client, {
         this._syncInitTime = new Date().getTime();
 
         var conn = new Core.Web.HttpConnection(this.getServiceUrl("Echo.Sync"), "POST", 
-                this._clientMessage._renderXml(), "text/xml");
+                this._clientMessage._renderXml(), "text/xml;charset=utf-8");
         
         // Create new client message.
         this._clientMessage = new Echo.RemoteClient.ClientMessage(this, null);

--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/service/WindowHtmlService.java
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/service/WindowHtmlService.java
@@ -117,6 +117,12 @@ implements Service {
             headElement.appendChild(metaCompElement);
         }
 
+        // Force UTF-8 document code for IE9. See http://echo.nextapp.com/site/node/6658
+        Element contentTypeElement = document.createElement("meta");
+        contentTypeElement.setAttribute("http-equiv", "Content-Type");
+        contentTypeElement.setAttribute("content", "text/html; charset=utf-8");
+        headElement.appendChild(contentTypeElement);
+
         Element titleElement = document.createElement("title");
         titleElement.appendChild(document.createTextNode(" "));
         headElement.appendChild(titleElement);


### PR DESCRIPTION
Modified patch from Andre published at http://echo.nextapp.com/site/node/6658
"I'm using the Extras.RichTextArea in my application. It works in most browsers. In IE9 I
got an exception when the input of the textarea is parsed on server side. The input source
tried to read the content as UTF-8. The internet explorer here created the editable iframe
with a document that has CP-1252 as charset encoding. Using characters like "äüö"
resulted in a crash of the application with the next try to sync.
For IE it is necessary to set the charset to UTF-8 after creating the document of the iframe."
