### PR TITLE
Various improvements to the Ant Build file for easier handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+lib
+dist
+build
+custom-ant.properties

--- a/ant.properties
+++ b/ant.properties
@@ -7,11 +7,12 @@ servlet.lib.jar                         ${env.SERVLET_LIB_JAR}
 servlet.lib.msg                         The environment variable SERVLET_LIB_JAR must contain the path to the Servlet 2.4 \
                                         specification JAR file (servlet.jar or servlet-api.jar).
 debug                                   yes
-jarfile.echo.app                        Echo3_App.jar
-jarfile.echo.webcontainer               Echo3_WebContainer.jar
-jarfile.style-converter                 Echo3_StyleConverter.jar
-warfile.testapp                         TestApp.war
-fileprefix.release                      NextApp_Echo
+jarfile.echo.app                        echo3-app-${release.version}.jar
+jarfile.echo.webcontainer               echo3-webcontainer-${release.version}.jar
+jarfile.style-converter                 echo3-styleconverter-${release.version}.jar
+srcfile.echo.app                        echo3-app-${release.version}-sources.jar
+srcfile.echo.webcontainer               echo3-webcontainer-${release.version}-sources.jar
+warfile.testapp                         testapp.war
 zipfile.release                         ${fileprefix.release}.${release.version}.zip
 tarfile.release                         ${fileprefix.release}.${release.version}.tar
 tgzfile.release                         ${fileprefix.release}.${release.version}.tgz

--- a/build.xml
+++ b/build.xml
@@ -32,6 +32,7 @@
 <project name="NextApp_Echo_3" default="dist" basedir=".">
 
     <property environment="env"/>
+    <property file="custom-ant.properties"/>
     <property file="ant.properties"/>
     
     <patternset id="fileset.resources">
@@ -96,7 +97,8 @@
     <target name="compile.app" description="Compile Echo Application Framework">
         <mkdir dir="${dir.build.server-java.app}"/>
         <javac srcdir="${dir.src.server-java.app}" destdir="${dir.build.server-java.app}" 
-                debug="${debug}" deprecation="yes" source="${ant.build.javac.source}" target="${ant.build.javac.target}"/>
+                debug="${debug}" deprecation="yes" source="${ant.build.javac.source}" 
+                target="${ant.build.javac.target}" includeantruntime="false" />
         <copy todir="${dir.build.server-java.app}">
             <fileset dir="${dir.src.server-java.app}">
                 <patternset refid="fileset.resources"/>
@@ -107,12 +109,14 @@
     <target name="dist.app" depends="clean,compile.app">
         <mkdir dir="${dir.dist.lib}"/>
         <jar jarfile="${dir.dist.lib}/${jarfile.echo.app}" basedir="${dir.build.server-java.app}"/>
+        <jar jarfile="${dir.dist.lib}/${srcfile.echo.app}" basedir="${dir.src.server-java.app}"/>
     </target>
     
     <target name="test.compile.app" depends="dist.app">
         <mkdir dir="${dir.build.server-java.app-test}"/>
         <javac srcdir="${dir.src.server-java.app-test}" destdir="${dir.build.server-java.app-test}" 
-                debug="${debug}" deprecation="yes" source="${ant.build.javac.source}" target="${ant.build.javac.target}">
+                debug="${debug}" deprecation="yes" source="${ant.build.javac.source}" 
+                target="${ant.build.javac.target}" includeantruntime="false">
             <classpath>
                 <pathelement path="${dir.dist.lib}/${jarfile.echo.app}"/>
             </classpath>
@@ -187,7 +191,8 @@
     <target name="compile.webcontainer.impl" depends="verify.servlet.api, compile.app">
         <mkdir dir="${dir.build.server-java.webcontainer}"/>
         <javac srcdir="${dir.src.server-java.webcontainer}" destdir="${dir.build.server-java.webcontainer}" 
-                debug="${debug}" deprecation="yes" source="${ant.build.javac.source}" target="${ant.build.javac.target}">
+                debug="${debug}" deprecation="yes" source="${ant.build.javac.source}" 
+                target="${ant.build.javac.target}" includeantruntime="false">
             <classpath>
                 <pathelement path="${dir.build.server-java.app}"/>
                 <pathelement path="${servlet.lib.jar}"/>
@@ -211,12 +216,14 @@
     <target name="dist.webcontainer" depends="clean,compile.webcontainer">
         <mkdir dir="${dir.dist.lib}"/>
         <jar jarfile="${dir.dist.lib}/${jarfile.echo.webcontainer}" basedir="${dir.build.server-java.webcontainer}"/>
+        <jar jarfile="${dir.dist.lib}/${srcfile.echo.webcontainer}" basedir="${dir.src.server-java.webcontainer}"/>
     </target>
     
     <target name="test.compile.webcontainer" depends="dist.app, dist.webcontainer">
         <mkdir dir="${dir.build.server-java.webcontainer-test}"/>
         <javac srcdir="${dir.src.server-java.webcontainer-test}" destdir="${dir.build.server-java.webcontainer-test}" 
-                debug="${debug}" deprecation="yes" source="${ant.build.javac.source}" target="${ant.build.javac.target}">
+                debug="${debug}" deprecation="yes" source="${ant.build.javac.source}" 
+                target="${ant.build.javac.target}" includeantruntime="false">
             <classpath>
                 <pathelement path="${dir.dist.lib}/${jarfile.echo.app}"/>
                 <pathelement path="${dir.dist.lib}/${jarfile.echo.webcontainer}"/>
@@ -299,7 +306,8 @@
     <target name="compile.style-converter" description="Compile Echo2-Echo3 Style Conversion Utility">
         <mkdir dir="${dir.build.util.style-converter}"/>
         <javac srcdir="${dir.src.util.style-converter}" destdir="${dir.build.util.style-converter}" 
-                debug="${debug}" deprecation="yes" source="${ant.build.javac.source}" target="${ant.build.javac.target}"/>
+                debug="${debug}" deprecation="yes" source="${ant.build.javac.source}" 
+                target="${ant.build.javac.target}" includeantruntime="false"/>
     </target>
     
     <target name="dist.style-converter" depends="clean,compile.style-converter">
@@ -323,7 +331,8 @@
             <fileset dir="${dir.src.server-java.test-ia.htdocs}"/>
         </copy>
         <javac srcdir="${dir.src.server-java.test-ia.lib}" destdir="${dir.build.server-java.testapp}/WEB-INF/classes" 
-                debug="${debug}" deprecation="yes" source="${ant.build.javac.source}" target="${ant.build.javac.target}">
+                debug="${debug}" deprecation="yes" source="${ant.build.javac.source}" 
+                target="${ant.build.javac.target}" includeantruntime="false">
             <classpath>
                 <pathelement path="${servlet.lib.jar}"/>
                 <pathelement path="${dir.dist.lib}/${jarfile.echo.app}"/>
@@ -425,11 +434,11 @@
     	if="onWindows">
         <exec executable="cmd">
             <arg value="/c"/>
-            <arg value="mvn install:install-file -DpomFile=resource/maven/echo3-app-pom.xml -Dfile=dist${file.separator}lib${file.separator}Echo3_App.jar"/>
+            <arg value="mvn install:install-file -DpomFile=resource/maven/echo3-app-pom.xml -Dfile=dist${file.separator}lib${file.separator}${jarfile.echo.app}"/>
             </exec>
             <exec executable="cmd">
                 <arg value="/c"/>
-                <arg value="mvn install:install-file -DpomFile=resource/maven/echo3-webcontainer-pom.xml -Dfile=dist${file.separator}lib${file.separator}Echo3_WebContainer.jar"/>
+                <arg value="mvn install:install-file -DpomFile=resource/maven/echo3-webcontainer-pom.xml -Dfile=dist${file.separator}lib${file.separator}${jarfile.echo.webcontainer}"/>
             </exec>
     </target>
 	
@@ -439,12 +448,12 @@
         <exec executable="mvn">
             <arg value="install:install-file"/>
         	<arg value="-DpomFile=resource/maven/echo3-app-pom.xml"/>
-            <arg value="-Dfile=dist${file.separator}lib${file.separator}Echo3_App.jar"/>
+            <arg value="-Dfile=dist${file.separator}lib${file.separator}echo3-app-${release.version}.jar"/>
         </exec>
         <exec executable="mvn">
             <arg value="install:install-file"/>
         	<arg value="-DpomFile=resource/maven/echo3-webcontainer-pom.xml"/>
-            <arg value="-Dfile=dist${file.separator}lib${file.separator}Echo3_WebContainer.jar"/>
+            <arg value="-Dfile=dist${file.separator}lib${file.separator}echo3-webcontainer-${release.version}.jar"/>
         </exec>
     </target>
     


### PR DESCRIPTION
- JAR file names naming aligned to maven style
- ommit Ant 1.8 warning
- Generate Source-JAR (Maven Style)
- Added a .gitignore file
- Allow optional 'custom-ant.properties' to avoid need of  environment vars
