### PR TITLE
Support for async (XHR) background requests which should not trigger the 

### DIFF
--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/resource/RemoteClient.js
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/resource/RemoteClient.js
@@ -232,7 +232,7 @@ Echo.RemoteClient = Core.extend(Echo.Client, {
         if(eventType && typeof eventType === "string") {
             // if it startsWith 'async_' return true ->
             if(eventType.length > 5) {
-                return (eventType.substring(0,5) === 'asnyc_');
+                return (eventType.substring(0,5) === 'async_');
             }
         }
         // if eventType is not a string or even null:


### PR DESCRIPTION
Support for async (XHR) background requests which should not trigger the 'please wait' indicator.

This feature enables you to use the Echo communication infrastructure to request i.e. Autocompletion
proposals from the server without triggering the blocking please wait indiciator after 100ms.

When redefining an eventType from 'eventType: fooBar' to eventType 'eventType: async_fooBar'
echo will not show the    waitIndicator and block the application while the server processes the event

See Echolot / Autocompletion Sync for an example
