### PR TITLE
Support for color "transparent" to allow glass/transparency effects on pa

### DIFF
--- a/src/client/echo/Sync.js
+++ b/src/client/echo/Sync.js
@@ -49,9 +49,11 @@ Echo.Sync = {
     renderComponentDefaults: function(component, element) {
         var color;
         if ((color = component.render("foreground"))) {
+            color = Echo.Sync.Color.toTransparent(color);
             element.style.color = color;
         }
         if ((color = component.render("background"))) {
+            color = Echo.Sync.Color.toTransparent(color);
             element.style.backgroundColor = color;
         }
         var font = component.render("font");
@@ -261,7 +263,7 @@ Echo.Sync.Border = {
         if (typeof(border) == "string") {
             // Parse the border.
             var parts = this._PARSER.exec(border);
-            return { size: parts[1], style: parts[2], color: parts[3] }; 
+            return { size: parts[1], style: parts[2], color: parts[3] };
         } else {
             // Parse an individual border side.
             return Echo.Sync.Border.parse(border.top || border.right || border.bottom || border.left);
@@ -425,6 +427,7 @@ Echo.Sync.Color = {
      */
     render: function(color, element, styleAttribute) {
         if (color) {
+            color = this.toTransparent(color);
             element.style[styleAttribute] = color;
         }
     },
@@ -450,9 +453,11 @@ Echo.Sync.Color = {
     renderFB: function(component, element) { 
         var color;
         if ((color = component.render("foreground"))) {
+            color = this.toTransparent(color);
             element.style.color = color;
         }
         if ((color = component.render("background"))) {
+            color = this.toTransparent(color);
             element.style.backgroundColor = color;
         }
     },
@@ -486,6 +491,18 @@ Echo.Sync.Color = {
         return "#" + (red < 16 ? "0" : "") + red.toString(16) +
                 (green < 16 ? "0" : "") + green.toString(16) +
                 (blue < 16 ? "0" : "") + blue.toString(16); 
+    },
+
+    /**
+     * Converts the color to 'transparent' if necessary
+     *
+     * @param {#Color} color to convert
+     * @return the converted color
+     * @type String
+     */
+    toTransparent: function(color) {
+        // the mask for 'transparent' is '#-1'
+        return (color == -1 || color == '#-1' || (color && color.toLowerCase() == '#transparent')) ? 'transparent' : color
     }
 };
 

--- a/src/server-java/app/nextapp/echo/app/Color.java
+++ b/src/server-java/app/nextapp/echo/app/Color.java
@@ -76,6 +76,9 @@ implements Serializable {
     /** The color pink. */
     public static final Color PINK      = new Color(0xff, 0xaf, 0xaf);
 
+    /** The identifier for 'transparent'-color */
+    public static final Color TRANSPARENT = new Color(-1);
+
     private int rgb;
     
     /** 

--- a/src/server-java/app/nextapp/echo/app/serial/property/ColorPeer.java
+++ b/src/server-java/app/nextapp/echo/app/serial/property/ColorPeer.java
@@ -45,6 +45,7 @@ public class ColorPeer
 implements SerialPropertyPeer {
 
     private static final String COLOR_MASK = "#000000";
+    private static final String COLOR_TRANSPARENT = "#transparent";
     
     /**
      * Generates a <code>Color</code> based on a string representation.
@@ -56,6 +57,9 @@ implements SerialPropertyPeer {
     public static final Color fromString(String value) 
     throws SerialException {
         try {
+            if(value.trim().toLowerCase().equals(COLOR_TRANSPARENT)) {
+                return Color.TRANSPARENT;
+            }
             int colorValue = Integer.parseInt(value.trim().substring(1), 16);
             return new Color(colorValue);
         } catch (IndexOutOfBoundsException ex) {
@@ -75,6 +79,10 @@ implements SerialPropertyPeer {
     public static final String toString(Color color) 
     throws SerialException {
         int rgb = color.getRgb();
+        if(rgb == -1 || color.equals(Color.TRANSPARENT)) {
+            // if we have TRANSPARENT, we return '#-1'
+            return COLOR_MASK.substring(0,1) + rgb;
+        }
         String colorString = Integer.toString(rgb, 16);
         return COLOR_MASK.substring(0, 7 - colorString.length()) + colorString;
     }


### PR DESCRIPTION
Support for color "transparent" to allow glass/transparency effects on panels etc.
- Allows setting '#transparent' as color in stylesheet or the use of 'Color.TRANSPARENT'.
- This setting will be parsed as css-style: 'transparent'
