### PR TITLE
Bugfix : Preserve lineThrough on unpressing buttons

### DIFF
--- a/src/client/echo/Sync.js
+++ b/src/client/echo/Sync.js
@@ -1185,7 +1185,7 @@ Echo.Sync.Font = {
             if (!font.typeface) {
                 element.style.fontFamily = "";
             }
-            if (!font.underline) {
+            if (!font.underline && !font.overline && !font.lineThrough) {
                 element.style.textDecoration = "";
             }
             if (!font.bold) {


### PR DESCRIPTION
The Echo.Sync.Font.renderClear() method is inappropriately
removing line-through text decorations on buttons when they
are pressed, etc. Here is the diff showing the fix.

Reported at: Bug & Fix reported on http://echo.nextapp.com/site/node/6689

Closes https://github.com/echo3/echo3/issues/11
