### PR TITLE
Serialize (if possible) the xmlDocument before sending via xmlHttpReques...

### DIFF
--- a/src/client/corejs/Core.Web.js
+++ b/src/client/corejs/Core.Web.js
@@ -778,6 +778,13 @@ Core.Web.Env = {
     QUIRK_UNLOADED_IMAGE_HAS_SIZE: null,
 
     /**
+     * Flag indicating if xml-documents should be serialized before
+     * sending them through a xmlHttp request.
+     * @type Boolean
+     */
+    QUIRK_SERIALIZE_XML_BEFORE_XML_HTTP_REQ: null,
+
+    /**
      * User-agent string, in lowercase.
      */
     _ua: null,
@@ -908,6 +915,11 @@ Core.Web.Env = {
                     // Enable 'garbage collection' on large associative arrays to avoid memory leak.
                     Core.Arrays.LargeMap.garbageCollectEnabled = true;
                 }
+            }
+            if(this.BROWSER_VERSION_MAJOR == 9) {
+                // Internet Explorer 9 Flags
+                // if false ie9 will re-format your xml by adding and removing linebreaks
+                this.QUIRK_SERIALIZE_XML_BEFORE_XML_HTTP_REQ = true;
             }
         } else if (this.ENGINE_GECKO) {
             this.QUIRK_KEY_PRESS_FIRED_FOR_SPECIAL_KEYS = true;
@@ -1465,12 +1477,12 @@ Core.Web.HttpConnection = Core.extend({
         }
 
         // Execute request.
-		// if there is a XMLSerializer available we serialize to prevent ie9 to delete or even insert newlines (ie9 tries to format any XML-Document sent by a xmlHttpRequest)
-		if(window.XMLSerializer) {
-		    this._xmlHttpRequest.send(this._messageObject ? new XMLSerializer().serializeToString(this._messageObject) : null);
-		} else {
-		    this._xmlHttpRequest.send(this._messageObject ? this._messageObject : null);
-		}
+        if (Core.Web.Env.QUIRK_SERIALIZE_XML_BEFORE_XML_HTTP_REQ) {
+            // serialize before sending
+            this._xmlHttpRequest.send(this._messageObject ? new XMLSerializer().serializeToString(this._messageObject) : null);
+        } else {
+            this._xmlHttpRequest.send(this._messageObject ? this._messageObject : null);
+        }
     },
     
     /**


### PR DESCRIPTION
...t due to an ie9 special behaviour on formatting xmlDoms's. IE9 removes all newlines from a xmlDocument and inserts some own newlines to pretty format the xml-Struture... Maybe this is a feature but in case of echo3 text syncs via xmlHttpRequest the format of a e.g. textArea is broken by this 'feature' of ie9

Based on varios discussions and some test's this might be the best way to prevent ie9 (nad maybe som upcomming releases of ie) to format xmlDocuments.
See here for more details:
http://social.msdn.microsoft.com/Forums/en-US/iewebdevelopment/thread/0e8c403d-3d46-4ba2-899e-54ed2261d1e3

This hotfix fixes some strange behavior described on forum:
http://echo.nextapp.com/site/node/6669
http://echo.nextapp.com/site/node/6686
