### PR TITLE
Support for async (XHR) background requests 

### DIFF
--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/resource/RemoteClient.js
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/resource/RemoteClient.js
@@ -221,6 +221,25 @@ Echo.RemoteClient = Core.extend(Echo.Client, {
     },
     
     /**
+     * Test a given event, if it is a async event.
+     * An async-event starts by convention with 'async_' on property eventType.
+     *
+     * @param eventType the string-identifier of the event
+     * @return true, if it is a async event, false if not
+     * @type Boolean
+     */
+    _isAsyncEvent: function(eventType) {
+        if(eventType && typeof eventType === "string") {
+            // if it startsWith 'async_' return true ->
+            if(eventType.length > 5) {
+                return (eventType.substring(0,5) === 'async_');
+            }
+        }
+        // if eventType is not a string or even null:
+        return false;
+    },
+
+    /**
      * Enqueues a command to be processed after component synchronization has been completed.
      * 
      * @param commandPeer the command peer to execute
@@ -399,7 +418,8 @@ Echo.RemoteClient = Core.extend(Echo.Client, {
             return;
         }
         this._clientMessage.setEvent(e.source.renderId, e.type, e.data);
-        if (!this._inputRestrictionId) {
+        // added: && !this._isAsyncEvent(e.type) to handle async events
+        if (!this._inputRestrictionId && !this._isAsyncEvent(e.type)) {
            this._inputRestrictionId = this.createInputRestriction();
         }
         this._syncRequested = true;
@@ -531,7 +551,8 @@ Echo.RemoteClient = Core.extend(Echo.Client, {
         
         this._transactionInProgress = true;
         this._syncRequested = false;
-        if (!this._inputRestrictionId) {
+        // added: && !this._isAsyncEvent(this._clientMessage._eventType) to handle async events
+        if (!this._inputRestrictionId && !this._isAsyncEvent(this._clientMessage._eventType)) {
             this._inputRestrictionId = this.createInputRestriction();
         }
 


### PR DESCRIPTION
which should not trigger the 'please wait' indicator.

This feature enables you to use the Echo communication infrastructure to request i.e. Autocompletion
proposals from the server without triggering the blocking please wait indiciator after 100ms.

When redefining an eventType from 'eventType: fooBar' to eventType 'eventType: async_fooBar'
echo will not show the    waitIndicator and block the application while the server processes the event

See Echolot / Autocompletion Sync for an example
