### PR TITLE
Call eval in the context of window...

### DIFF
--- a/src/client/corejs/Core.Web.js
+++ b/src/client/corejs/Core.Web.js
@@ -2035,8 +2035,8 @@ Core.Web.Library = {
     		// We use an anonymous function so that context is window
 			// rather than _Item in Firefox
 			(window.execScript || function(data) {
-				window["eval"].call(window, this._content);
-			})(data);
+				window["eval"].call(window, data);
+			})(this._content);
         },
         
         /**


### PR DESCRIPTION
Call eval in the context of window to be able to load libraries that put things in the global scope using var x=... (like prototype.js)
