### PR TITLE
Refocus Sync.ListComponent's select element if it was focused before renderUpdate

### DIFF
--- a/src/client/echo/Sync.List.js
+++ b/src/client/echo/Sync.List.js
@@ -484,6 +484,9 @@ Echo.Sync.ListComponent = Core.extend(Echo.Render.ComponentSync, {
         this.renderDispose(update);
         containerElement.removeChild(element);
         this.renderAdd(update, containerElement);
+        if (this._focused) {
+            Core.Web.DOM.focusElement(this._element);
+        }
         return false; // Child elements not supported: safe to return false.
     },
     


### PR DESCRIPTION
Because Sync.ListComponent removes the old html select field and creates a new one in renderUpdate(), the browser focus is lost. This fix refocuses the field in renderUpdate if it was focused before.
