### PR TITLE
Remove unneeded div-wrapper of Sync.ListComponent

### DIFF
--- a/src/client/echo/Sync.List.js
+++ b/src/client/echo/Sync.List.js
@@ -351,8 +351,6 @@ Echo.Sync.ListComponent = Core.extend(Echo.Render.ComponentSync, {
      * @param {Element} parent the parent DOM element 
      */
     _renderMainAsSelect: function(update, parentElement) {
-        this._div = document.createElement("div");
-    
         this._element = document.createElement("select");
         this._element.id = this.component.renderId;
         this._element.size = this.listBox ? 6 : 1;
@@ -370,8 +368,7 @@ Echo.Sync.ListComponent = Core.extend(Echo.Render.ComponentSync, {
         if (width) {
             if (Echo.Sync.Extent.isPercent(width)) {
                 if (!Core.Web.Env.QUIRK_IE_SELECT_PERCENT_WIDTH) {
-                    this._div.style.width = width;
-                    this._element.style.width = "100%";
+                    this._element.style.width = width;
                 }
             } else {
                 this._element.style.width = Echo.Sync.Extent.toCssValue(width, true, false);
@@ -419,9 +416,7 @@ Echo.Sync.ListComponent = Core.extend(Echo.Render.ComponentSync, {
             Core.Web.Event.add(this._element, "focus", Core.method(this, this._processFocus), false);
         }
 
-        this._div.appendChild(this._element);
-
-        parentElement.appendChild(this._div);
+        parentElement.appendChild(this._element);
     },
 
     /**


### PR DESCRIPTION
_renderMainAsSelect wrapped the select field with a div, contrary to the
comment of the _div attribute. On renderUpdate calls, this div remained in
the DOM causing an increasingly deep hierarchy of div wrappers around
the select element. This fix removes the div and puts the select field right below the parent element.
