### PR TITLE
Fix build process by removing Jetty import

### DIFF
--- a/src/server-java/testapp-interactive/lib/nextapp/echo/testapp/interactive/InteractiveServlet.java
+++ b/src/server-java/testapp-interactive/lib/nextapp/echo/testapp/interactive/InteractiveServlet.java
@@ -29,7 +29,6 @@
 
 package nextapp.echo.testapp.interactive;
 
-import jetty.JettyWebSocket;
 import nextapp.echo.app.ApplicationInstance;
 import nextapp.echo.webcontainer.ApplicationWebSocket;
 import nextapp.echo.webcontainer.Service;
@@ -68,7 +67,12 @@ public class InteractiveServlet extends WebContainerServlet {
     public static final WebSocketConnectionHandler wsHandler = new WebSocketConnectionHandler() {
         @Override
         public ApplicationWebSocket newApplicationWebSocket(ApplicationInstance applicationInstance) {
-            return new JettyWebSocket();
+            try {
+                Class<?> clazz = Class.forName("jetty.JettyWebSocket");
+                return (ApplicationWebSocket)clazz.newInstance();
+            } catch (Exception e) {
+            }
+            return null;
         }
     };
 


### PR DESCRIPTION
I used Class.forName() for a dynamic class lookup, in order to not add an additional (and not actually used) Maven dependency.

Note: Consider this an intermediate solution until a more (Maven-) standard-like project structure has been set up
