### PR TITLE
Allow manual component registration

### DIFF
--- a/src/server-java/app/nextapp/echo/app/util/PeerFactory.java
+++ b/src/server-java/app/nextapp/echo/app/util/PeerFactory.java
@@ -34,7 +34,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import nextapp.echo.app.util.PropertiesDiscovery;
+import nextapp.echo.app.Component;
 
 /**
  * A mechanism for retrieving instances of singleton peer objects which are 
@@ -48,7 +48,10 @@ import nextapp.echo.app.util.PropertiesDiscovery;
  */
 public class PeerFactory {
     
-    private final Map objectClassNameToPeerMap = new HashMap();
+    /**
+     * Maps a component (identified by its canonical name) to its peer
+     */
+    private final Map<String, Object> objectClassNameToPeerMap = new HashMap<String, Object>();
     
     /**
      * Creates a new <code>PeerFactory</code>.
@@ -68,7 +71,7 @@ public class PeerFactory {
             while (it.hasNext()) {
                 String objectClassName = ((String) it.next()).trim();
                 String peerClassName = ((String) peerNameMap.get(objectClassName)).trim();
-                Class peerClass = classLoader.loadClass(peerClassName);
+                Class<?> peerClass = classLoader.loadClass(peerClassName);
                 Object peer = peerClass.newInstance();
                 objectClassNameToPeerMap.put(objectClassName, peer);
             }
@@ -113,5 +116,15 @@ public class PeerFactory {
             }
         } while (searchSuperClasses && objectClass != null);
         return null;
+    }
+
+    /**
+     * Register a peer to its corresponding component class
+     * 
+     * @param componentClass The class of the component to register
+     * @param peer The peer instance for the component
+     */
+    public void registerPeer(Class<? extends Component> componentClass, Object peer) {
+        objectClassNameToPeerMap.put(componentClass.getCanonicalName(), peer);
     }
 }

--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/SynchronizePeerFactory.java
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/SynchronizePeerFactory.java
@@ -29,7 +29,12 @@
 
 package nextapp.echo.webcontainer;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import nextapp.echo.app.Component;
 import nextapp.echo.app.util.PeerFactory;
+
 
 /**
  * Factory for obtaining <code>XXXSynchronizePeer</code> implementations.
@@ -42,7 +47,10 @@ public class SynchronizePeerFactory {
     /** Peer factory for retrieving synchronization peers. */
     private static final PeerFactory peerFactory 
             = new PeerFactory(RESOURCE_NAME, Thread.currentThread().getContextClassLoader());
-    
+
+    /** Peer factory for retrieving synchronization peers. */
+    private static final Map<Class, ComponentSynchronizePeer> peerRegistry = new HashMap<Class, ComponentSynchronizePeer>();
+
     /**
      * Non-instantiable class.
      */
@@ -80,6 +88,22 @@ public class SynchronizePeerFactory {
      * @return the appropriate <code>ComponentSynchronizePeer</code>
      */
     public static ComponentSynchronizePeer getPeerForComponent(Class componentClass, boolean searchSuperClasses) {
-        return (ComponentSynchronizePeer) peerFactory.getPeerForObject(componentClass, searchSuperClasses);
+        ComponentSynchronizePeer peer = peerRegistry.get(componentClass);
+        if (peer == null) {
+            peer = (ComponentSynchronizePeer) peerFactory.getPeerForObject(componentClass, searchSuperClasses);
+        }
+        return peer;
+    }
+    
+    /**
+     * Register manually a peer for a given component class
+     * Peers do not have to be registered in SynchronizePeerBindings.properties
+     * 
+     * @param componentClass the component class
+     * @param peer the peer corresponding to the component class
+     */
+    public static void registerSynchronizePeer(Class<? extends Component> componentClass, ComponentSynchronizePeer peer) {
+        peerRegistry.put(componentClass, peer);
+        peerFactory.registerPeer(componentClass, peer);
     }
 }


### PR DESCRIPTION
Proposal for a manual component registration as an alternative of using the SynchronizePeerBindings.properties file).

The objective of this approach is obviating the need for creating (boiler-platy) peer components, and using a very simple declarative approach instead, such as illustrated here: 

![image](https://f.cloud.github.com/assets/3050757/696187/a86557da-dce0-11e2-9a81-081d9d373e77.png)

For more code snippets see Gist at https://gist.github.com/chrismay2/5850658
