### PR TITLE
Fix width of text fields in tables in IE 8+

### DIFF
--- a/src/client/echo/Sync.TextComponent.js
+++ b/src/client/echo/Sync.TextComponent.js
@@ -297,12 +297,16 @@ Echo.Sync.TextComponent = Core.extend(Echo.Render.ComponentSync, {
             if (Core.Web.Env.ENGINE_MSHTML) {
                 // Add additional 1px for IE.
                 borderSize += 1;
-                // Add default windows scroll bar width to border size for Internet Explorer browsers.
-                if (this.container) {
-                    this.container.style.width = this._adjustPercentWidth(100, Core.Web.Measure.SCROLL_WIDTH, 
-                            this.input.parentNode.offsetWidth) + "%";
-                } else {
-                    borderSize += Core.Web.Measure.SCROLL_WIDTH;
+                // Add default windows scroll bar width to border size for Internet Explorer browsers. Seems to be not
+                // needed in IE versions 8 and higher and instead causes problems when text components are embedded in
+                // e.g. tables.
+                if (Core.Web.Env.BROWSER_VERSION_MAJOR < 8) {
+                    if (this.container) {
+                        this.container.style.width = this._adjustPercentWidth(100, Core.Web.Measure.SCROLL_WIDTH,
+                                this.input.parentNode.offsetWidth) + "%";
+                    } else {
+                        borderSize += Core.Web.Measure.SCROLL_WIDTH;
+                    }
                 }
             } else if (Core.Web.Env.BROWSER_CHROME && this.input.nodeName.toLowerCase() == "textarea") {
                 // Add additional 3px to TEXTAREA elements for Chrome.


### PR DESCRIPTION
Special handling of Internet Explorer when the width of a text field is specified
as percentage seems to be no longer needed. Instead, this caused the calculated width
to be too short when the text field is rendered inside a table.

It _seems_ to work but I'm not sure if I tested and thought of all the cases this calculation was originally done for.
