### PR TITLE
Echo configuration via system & servlet properties

### DIFF
--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/InputProcessor.java
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/InputProcessor.java
@@ -141,13 +141,13 @@ public class InputProcessor {
             // Flag full refresh for an out of sync client.
             updateManager.getServerUpdateManager().processFullRefresh();
             this.syncState.setOutOfSync();
-            if (WebContainerServlet.DEBUG_PRINT_MESSAGES_TO_CONSOLE) {
+            if (ServerConfiguration.DEBUG_PRINT_MESSAGES_TO_CONSOLE) {
                 Log.log("Client out of sync: client id = " + clientMessage.getTransactionId() + 
                         ", server id = " + userInstance.getCurrentTransactionId());
             }
         }
         
-        if (WebContainerServlet.DEBUG_PRINT_MESSAGES_TO_CONSOLE) {
+        if (ServerConfiguration.DEBUG_PRINT_MESSAGES_TO_CONSOLE) {
             // Print ClientMessage to console. 
             try {
                 System.err.println("======== Request: " + userInstance.getCurrentTransactionId() + " ========");

--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/OutputProcessor.java
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/OutputProcessor.java
@@ -183,7 +183,7 @@ class OutputProcessor {
             throw new SynchronizationException("Cannot serialize server state.", ex);
         }
         
-        if (WebContainerServlet.DEBUG_PRINT_MESSAGES_TO_CONSOLE) {
+        if (ServerConfiguration.DEBUG_PRINT_MESSAGES_TO_CONSOLE) {
             // Print ServerMessage DOM to console. 
             try {
                 System.err.println("======== Response: " + userInstance.getCurrentTransactionId() + " ========");

--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/ServerConfiguration.java
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/ServerConfiguration.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of the Echo Web Application Framework (hereinafter "Echo").
+ * Copyright (C) 2002-2009 NextApp, Inc.
+ *
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ */
+
+package nextapp.echo.webcontainer;
+
+import java.util.Map;
+
+/**
+ * Holds configuration values that are read from system properties and from servlet
+ * init parameters. System properties have precedence over init parameters.
+ */
+public class ServerConfiguration {
+    /**
+     * Debug mode
+     */
+    public static boolean DEBUG;
+
+    /**
+     * Flag indicating whether client/server messages should be dumped to console.
+     */
+    public static boolean DEBUG_PRINT_MESSAGES_TO_CONSOLE;
+
+    /**
+     * Toggle to enable GZIP compression for MS IE Browser via property 'echo.allowiecompression'
+     */
+    public static boolean ALLOW_IE_COMPRESSION;
+
+    /**
+     * Toggle to disable JavaScript compression via property 'echo.javascript.compression'
+     */
+    public static boolean JAVASCRIPT_COMPRESSION_ENABLED;
+
+    /**
+     * Include the meta tag http-equiv"X-UA-Compatible" content="IE=edge", which tells IE to always use
+     * the latest rendering engine available, instead of compatibility mode.
+     */
+    public static boolean IE_EDGE_MODE;
+
+    static {
+        // Initialize configuration with System properties, if available
+        readConfiguration(null);
+    }
+
+    /**
+     * Reads the configuration from system properties and servlet init parameters.
+     *
+     * @param initParameters optional servlet init parameters
+     */
+    private static void readConfiguration(Map initParameters) {
+        DEBUG = getConfigValue("echo.debug", initParameters, false);
+        DEBUG_PRINT_MESSAGES_TO_CONSOLE = getConfigValue("echo.syncdump", initParameters, false);
+        ALLOW_IE_COMPRESSION = getConfigValue("echo.allowiecompression", initParameters, false);
+        JAVASCRIPT_COMPRESSION_ENABLED = getConfigValue("echo.javascript.compression", initParameters, false);
+        IE_EDGE_MODE = getConfigValue("echo.ie-edge-mode", initParameters, true);
+    }
+
+    /**
+     * Update configuration with servlet init parameters
+     * @param initParameters
+     */
+    public static void adoptServletConfiguration(Map initParameters) {
+        readConfiguration(initParameters);
+    }
+
+    /**
+     * Returns the configuration value for the given name.
+     *
+     * @param name name of the configuration value
+     * @param initParameters map of servlet init parameters
+     * @param defaultValue default value, if neither a system property nor a servlet init parameter exists
+     * @return the value of the configuration parameter with the given name
+     */
+    private static String getConfigValue(String name, Map initParameters, String defaultValue) {
+        if (System.getProperties().containsKey(name)) {
+            return System.getProperty(name);
+        }
+        else if (initParameters != null && initParameters.containsKey(name)) {
+            return (String)initParameters.get(name);
+        }
+        return defaultValue;
+    }
+
+    private static boolean getConfigValue(String name, Map initParameters, boolean defaultValue) {
+        return Boolean.valueOf(getConfigValue(name, initParameters, String.valueOf(defaultValue))).booleanValue();
+    }
+}

--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/WebContainerServlet.java
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/WebContainerServlet.java
@@ -42,10 +42,7 @@ import nextapp.echo.webcontainer.service.SynchronizeService;
 import nextapp.echo.webcontainer.service.WindowHtmlService;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -59,20 +56,8 @@ import javax.servlet.http.HttpServletResponse;
  * deployment descriptor.
  */
 public abstract class WebContainerServlet extends HttpServlet {
-    
-    /**
-     * Flag indicating whether client/server messages should be dumped to console.
-     */
-    public static final boolean DEBUG_PRINT_MESSAGES_TO_CONSOLE;
-    static {
-        boolean value;
-        try {
-            value = "true".equals(System.getProperty("echo.syncdump"));
-        } catch (SecurityException ex) {
-            value = false;
-        }
-        DEBUG_PRINT_MESSAGES_TO_CONSOLE = value;
-    }
+
+
     
     /** A <code>ThreadLocal</code> reference to the <code>Connection</code> relevant to the current thread. */ 
     private static final ThreadLocal activeConnection = new ThreadLocal();
@@ -263,7 +248,29 @@ public abstract class WebContainerServlet extends HttpServlet {
         services.add(WindowHtmlService.INSTANCE);
         services.add(AsyncMonitorService.INSTANCE);
     }
-    
+
+    public void init() throws ServletException {
+        super.init();
+
+        // Read servlet init parameters and update server configuration
+        ServerConfiguration.adoptServletConfiguration(getInitParameterMap());
+    }
+
+    /**
+     * Return the servlet's init parameters as a map.
+     *
+     * @return servlet init parameters as map
+     */
+    private Map getInitParameterMap() {
+        Map initParameters = new HashMap();
+        Enumeration parameterNames = getInitParameterNames();
+        while (parameterNames.hasMoreElements()) {
+            String name = (String) parameterNames.nextElement();
+            initParameters.put(name, getInitParameter(name));
+        }
+        return initParameters;
+    }
+
     /**
      * Adds a JavaScript service to be loaded at initialization.
      * 

--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/service/JavaScriptService.java
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/service/JavaScriptService.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.security.AccessControlException;
 
 import nextapp.echo.webcontainer.Connection;
+import nextapp.echo.webcontainer.ServerConfiguration;
 import nextapp.echo.webcontainer.Service;
 import nextapp.echo.webcontainer.util.GZipCompressor;
 import nextapp.echo.webcontainer.util.JavaScriptCompressor;
@@ -43,31 +44,6 @@ import nextapp.echo.webcontainer.util.Resource;
  */
 public class JavaScriptService 
 implements Service {
-
-    // Toggle to enable GZIP compression for MS IE Browser via system property 'echo.allowiecompression'
-    private static final boolean ALLOW_IE_COMPRESSION;
-    static {
-        boolean allowiecompression = false;
-        try {
-            if ("true".equals(System.getProperty("echo.allowiecompression"))) {
-                allowiecompression = true;
-            }
-        }
-        catch (AccessControlException ignored) {} // if running under a security manager
-        ALLOW_IE_COMPRESSION = allowiecompression;
-    }
-    // Toggle to disable JavaScript compression via system property 'echo.javascript.compression'
-    private static final boolean JAVASCRIPT_COMPRESSION_ENABLED;
-    static {
-        Boolean value = Boolean.FALSE;
-        try {
-            value = Boolean.valueOf(System.getProperty("echo.javascript.compression", Boolean.TRUE.toString()));
-        } catch (SecurityException ex) {
-            System.err.println("SystemProperty 'echo.javascript.compression.disabled' not set, SecurityException " + ex.getMessage());
-        }
-        JAVASCRIPT_COMPRESSION_ENABLED = value.booleanValue();
-    }
-
     /**
      * Creates a new <code>JavaScript</code> service from the specified
      * resource in the <code>CLASSPATH</code>.
@@ -109,7 +85,7 @@ implements Service {
     public JavaScriptService(String id, String content) {
         super();
         this.id = id;
-        this.content = JAVASCRIPT_COMPRESSION_ENABLED ? JavaScriptCompressor.compress(content) : content;
+        this.content = ServerConfiguration.JAVASCRIPT_COMPRESSION_ENABLED ? JavaScriptCompressor.compress(content) : content;
         try {
             gzipContent = GZipCompressor.compress(this.content);
         } catch (IOException ex) {
@@ -142,7 +118,7 @@ implements Service {
     public void service(Connection conn) 
     throws IOException {
         String userAgent = conn.getRequest().getHeader("user-agent");
-        if (!ALLOW_IE_COMPRESSION && (userAgent == null || userAgent.indexOf("MSIE") != -1)) {
+        if (!ServerConfiguration.ALLOW_IE_COMPRESSION && (userAgent == null || userAgent.indexOf("MSIE") != -1)) {
             // Due to behavior detailed Microsoft Knowledge Base Article Id 312496, 
             // all HTTP compression support is disabled for this browser.
             // Due to the fact that ClientProperties information is not necessarily 

--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/service/WindowHtmlService.java
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/service/WindowHtmlService.java
@@ -36,6 +36,7 @@ import java.util.regex.Pattern;
 
 import javax.xml.transform.OutputKeys;
 
+import nextapp.echo.webcontainer.*;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Text;
@@ -43,12 +44,6 @@ import org.xml.sax.SAXException;
 
 import nextapp.echo.app.ApplicationInstance;
 import nextapp.echo.app.util.DomUtil;
-import nextapp.echo.webcontainer.Connection;
-import nextapp.echo.webcontainer.ContentType;
-import nextapp.echo.webcontainer.Service;
-import nextapp.echo.webcontainer.UserInstanceContainer;
-import nextapp.echo.webcontainer.SynchronizationException;
-import nextapp.echo.webcontainer.WebContainerServlet;
 
 /**
  * Completely re-renders a browser window.
@@ -109,7 +104,13 @@ implements Service {
         metaGeneratorElement.setAttribute("content", ApplicationInstance.ID_STRING);
         headElement.appendChild(metaGeneratorElement);
 
-        if (userAgent != null && USER_AGENT_MSIE8.matcher(userAgent).find()) {
+        if (ServerConfiguration.IE_EDGE_MODE) {
+            Element metaCompElement = document.createElement("meta");
+            metaCompElement.setAttribute("http-equiv", "X-UA-Compatible");
+            metaCompElement.setAttribute("content", "IE=edge");
+            headElement.appendChild(metaCompElement);
+        }
+        else if (userAgent != null && USER_AGENT_MSIE8.matcher(userAgent).find()) {
             // Force Internet Explorer 8 standards-compliant mode.
             Element metaCompElement = document.createElement("meta");
             metaCompElement.setAttribute("http-equiv", "X-UA-Compatible");
@@ -138,7 +139,7 @@ implements Service {
         scriptElement.setAttribute("type", "text/javascript");
         scriptElement.setAttribute("src", userInstanceContainer.getServiceUri(BootService.SERVICE, null));
         headElement.appendChild(scriptElement);
-        
+
         WebContainerServlet servlet = conn.getServlet();
         
         // Include application-provided initialization scripts.
@@ -204,8 +205,7 @@ implements Service {
      */
     public void service(Connection conn) throws IOException {
         try {
-            boolean debug = !("false".equals(conn.getServlet().getInitParameter("echo.debug")));
-            Document document = createHtmlDocument(conn, debug);
+            Document document = createHtmlDocument(conn, ServerConfiguration.DEBUG);
             conn.setContentType(ContentType.TEXT_HTML);
             DomUtil.save(document, conn.getWriter(), OUTPUT_PROPERTIES);
         } catch (SAXException ex) {


### PR DESCRIPTION
This change introduces a ServerConfiguration class that provides
access to both system and servlet init parameters, which can be used
to configure certain Echo behaviour. Existing code that read only system
properties was migrated to use the new class instead.

If a system property is specified, it takes precedence over a servlet
init parameter with the same name, which means this change should be
backwards compatible with existing Echo applications.

Additionally, the IE_EDGE_MODE configuration option was added. If enabled,
Echo will include a X-UA-Compatible meta tag with value 'IE=edge', which
tells Internet Explorer to always use the latest rendering engine.

Resolves #63
Resolves #56
