### PR TITLE
Include font resources in interactive testapp compilation

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -18,6 +18,11 @@
       <entry name="?*.tld" />
       <entry name="?*.js" />
       <entry name="?*.css" />
+      <entry name="?*.eot" />
+      <entry name="?*.ttf" />
+      <entry name="?*.svg" />
+      <entry name="?*.otf" />
+      <entry name="?*.woff" />
     </wildcardResourcePatterns>
     <annotationProcessing>
       <profile default="true" name="Default" enabled="false">

--- a/build.xml
+++ b/build.xml
@@ -45,6 +45,11 @@
         <include name="**/*xml"/>
         <include name="**/*stylesheet"/>
         <include name="**/*css"/>
+        <include name="**/*.eot"/>
+        <include name="**/*.otf"/>
+        <include name="**/*.svg"/>
+        <include name="**/*.ttf"/>
+        <include name="**/*.woff"/>
     </patternset>
     
     <target name="-check.dependencies">


### PR DESCRIPTION
Resource files introduced in 603f72b1b4 weren't included in the test application WAR file and IntelliJ artifact compilation processes.
