### PR TITLE
Show stack trace in error message

### DIFF
--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/resource/RemoteClient.js
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/resource/RemoteClient.js
@@ -1386,7 +1386,7 @@ Echo.RemoteClient.ServerMessage = Core.extend({
                 this.client._asyncManager._start();
             }
         } catch (ex) {
-            this.client.fail("Exception: " + ex);
+            this.client.fail("Exception: " + ex + " -> " + ex.stack);
         }
     },
     


### PR DESCRIPTION
Show the stacktrace information in the error screen

Otherwise it can be very difficult to trace down errors, especially when occuring on a remote customer site.
