### PR TITLE
Semi-transparent overlay behind modal windows

### DIFF
--- a/src/client/echo/Application.js
+++ b/src/client/echo/Application.js
@@ -416,6 +416,11 @@ Echo.Application = Core.extend({
         Core.Arrays.remove(this._modalComponents, component);
         if (modal) {
             this._modalComponents.push(component);
+        } else {
+            // Component is removed from the list of modal components, therefor its modal status should also be
+            // unset so the calls to getModalContextRoot() below and in the modal event listeners don't consider
+            // it modal anymore
+            component.set('modal', false);
         }
         
         // Auto-focus first component in modal context if component is currently focused component is not within modal context.

--- a/src/client/echo/Sync.ContentPane.js
+++ b/src/client/echo/Sync.ContentPane.js
@@ -76,7 +76,7 @@ Echo.Sync.ContentPane = Core.extend(Echo.Render.ComponentSync, {
         this._div.style.position = "absolute";
         this._div.style.width = "100%";
         this._div.style.height = "100%";
-        this._div.style.overflow = "hidden";
+        this._div.style.overflow = "visible";
         this._div.style.zIndex = "0";
         
         Echo.Sync.renderComponentDefaults(this.component, this._div);
@@ -247,7 +247,7 @@ Echo.Sync.ContentPane = Core.extend(Echo.Render.ComponentSync, {
     _renderFloatingPaneZIndices: function() {
         for (var i = 0; i < this._floatingPaneStack.length; ++i) {
             var childElement = this._childIdToElementMap[this._floatingPaneStack[i].renderId];
-            childElement.style.zIndex = 2 + i;
+            childElement.style.zIndex = 3 + i;
         }
         this._zIndexRenderRequired = false;
     },

--- a/src/client/echo/Sync.SplitPane.js
+++ b/src/client/echo/Sync.SplitPane.js
@@ -677,7 +677,7 @@ Echo.Sync.SplitPane = Core.extend(Echo.Render.ComponentSync, {
     
         this._splitPaneDiv = document.createElement("div");
         this._splitPaneDiv.id = this.component.renderId;
-        this._splitPaneDiv.style.cssText = "position:absolute;overflow:hidden;top:0;left:0;right:0;bottom:0;";
+        this._splitPaneDiv.style.cssText = "position:absolute;overflow:visible;top:0;left:0;right:0;bottom:0;";
         
         Echo.Sync.renderComponentDefaults(this.component, this._splitPaneDiv);
         
@@ -755,7 +755,7 @@ Echo.Sync.SplitPane = Core.extend(Echo.Render.ComponentSync, {
             }
         }
         if (child.pane) {
-            paneDiv.style.overflow = "hidden";
+            paneDiv.style.overflow = "visible";
         }
                 
         // Set static CSS positioning attributes on pane DIV.


### PR DESCRIPTION
When opening a modal window, a semi-transparent black overlay is shown
over all components not in the modal context (i.e. not usable while the window
is open)

Resolves #62
