### PR TITLE
 Show warnings if JS is disabled or when the detected browser version is outdated

### DIFF
--- a/src/client/echo/FreeClient.js
+++ b/src/client/echo/FreeClient.js
@@ -103,6 +103,9 @@ Echo.FreeClient = Core.extend(Echo.Client, {
      */
     init: function() {
         Core.Web.init();
+        if (this._isBrowserOutdated()) {
+            this._showBrowserWarning();
+        }
         this.application.updateManager.addUpdateListener(this._processUpdateRef);
     },
     

--- a/src/server-java/testapp-interactive/lib/nextapp/echo/testapp/interactive/InteractiveServlet.java
+++ b/src/server-java/testapp-interactive/lib/nextapp/echo/testapp/interactive/InteractiveServlet.java
@@ -55,6 +55,9 @@ public class InteractiveServlet extends WebContainerServlet {
 
     private static final Service CUSTOM_STYLE_SHEET = StaticTextService.forResource("CustomCSS", "text/css",
             "nextapp/echo/testapp/interactive/resource/css/Custom.css");
+
+    private static final Service CUSTOM_OUTDATED_BROWSER_WARNING = JavaScriptService.forResource("CustomOutdatedBrowserWarning",
+            "nextapp/echo/testapp/interactive/resource/js/CustomOutdatedBrowserWarning.js");
     
     public InteractiveServlet() {
         super();
@@ -64,6 +67,7 @@ public class InteractiveServlet extends WebContainerServlet {
         if (USE_CUSTOM_CSS) {
             addInitStyleSheet(CUSTOM_STYLE_SHEET);
         }
+        addInitScript(CUSTOM_OUTDATED_BROWSER_WARNING);
     }
     
     /**

--- a/src/server-java/testapp-interactive/lib/nextapp/echo/testapp/interactive/resource/js/CustomOutdatedBrowserWarning.js
+++ b/src/server-java/testapp-interactive/lib/nextapp/echo/testapp/interactive/resource/js/CustomOutdatedBrowserWarning.js
@@ -1,0 +1,65 @@
+/**
+ * Custom outdated browser warning implementation
+ */
+CustomOutdatedBrowserWarning = Core.extend(Echo.Client.OutdatedBrowserWarning, {
+    $static: {
+
+        boot: function(client) {
+            client.setOutdatedBrowserWarning(new CustomOutdatedBrowserWarning());
+        }
+    },
+
+    $load: function() {
+        Echo.Boot.addInitMethod(this.boot);
+    },
+
+    /** Container div */
+    _div: null,
+
+    /** Anchor element within the container div used to dismiss the warning */
+    _aClose: null,
+
+    /** Creates a new DefaultWaitIndicator. */
+    $construct: function() {
+        this._div = document.createElement("div");
+        this._div.id = "outdatedBrowserHint";
+
+        // Style the message window
+        this._div.style.cssText = "border: 4px solid red; position:relative; z-index:32767; left: 10px; top: 10px; width: 300px; height: 100px; overflow:hidden; " +
+            "background-color:white;color:black;text-align:center;padding:10px";
+
+        // Anchor element that can be clicked to dismiss the warning
+        this._aClose = document.createElement("a");
+        this._aClose.style.cssText = "text-decoration: underline; cursor: pointer; color: blue;";
+        this._aClose.setAttribute("onClick", "document.getElementById('"+this._div.id+"').parentNode.removeChild(document.getElementById('"+this._div.id+"')); return false;");
+    },
+
+    /** @see Echo.Client.OutdatedBrowserWarning#show */
+    show: function(client) {
+        if (client.configuration && client.configuration["OutdatedBrowserWarning.Text"]) {
+            this._div.innerHTML = client.configuration["OutdatedBrowserWarning.Text"];
+        } else {
+            this._div.innerHTML = 'I am a custom outdated browser warning. It seems you are using an outdated browser. Please consider upgrading: ' +
+                '<a href="http://whatbrowser.org">http://whatbrowser.org</a> ';
+        }
+
+        if (client.configuration && client.configuration["OutdatedBrowserWarning.CloseText"]) {
+            this._aClose.innerHTML = client.configuration["OutdatedBrowserWarning.CloseText"];
+        } else {
+            this._aClose.innerHTML = "Click to dismiss the warning";
+        }
+
+        this._div.appendChild(this._aClose);
+
+        // Insert div as the first child of the parent element of the application root element (usually the body)
+        client.domainElement.parentNode.insertBefore(this._div, client.domainElement);
+    },
+
+    /** @see Echo.Client.OutdatedBrowserWarning#dispose */
+    dispose: function(client) {
+        if (this._div && this._div.parentNode) {
+            this._div.parentNode.removeChild(this._div);
+        }
+        this._div = null;
+    }
+});

--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/ClientConfiguration.java
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/ClientConfiguration.java
@@ -41,7 +41,7 @@ public class ClientConfiguration
 implements Serializable {
     
     /** Serial Version UID. */
-    private static final long serialVersionUID = 20070101L;
+    private static final long serialVersionUID = 20130812L;
 
     /**
      * Property name constant for the alert message which should be displayed in
@@ -98,6 +98,21 @@ implements Serializable {
      * Property name constant for wait indicator background.  Must be a <code>Color</code> value.
      */
     public static final String WAIT_INDICATOR_BACKGROUND = "WaitIndicator.Background";
+
+    /**
+     * Property name constant for boolean flag indicating whether the warning message should *not* be displayed
+     * in the browser even if the browser version is unsupported by the client-side JavaScript implementation.
+     */
+    public static final String OUTDATED_BROWSER_NO_WARNING = "OutdatedBrowserWarning.NoWarning";
+
+    /**
+     * Property name constant for message to display when an outdated browser version is detected.
+     */
+    public static final String OUTDATED_BROWSER_MESSAGE = "OutdatedBrowserWarning.Text";
+    /**
+     * Property name constant for the text in the anchor that can be clicked to close the message.
+     */
+    public static final String OUTDATED_BROWSER_CLOSE = "OutdatedBrowserWarning.CloseText";
 
     /**
      * Mapping from property names to property values.

--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/ServerConfiguration.java
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/ServerConfiguration.java
@@ -62,6 +62,16 @@ public class ServerConfiguration {
      */
     public static boolean IE_EDGE_MODE;
 
+    /**
+     * Message to display when the browser does not have JavaScript enabled.
+     */
+    public static String NOSCRIPT_MESSAGE;
+
+    /**
+     * URL to display as link following the message when JavaScript is disabled.
+     */
+    public static String NOSCRIPT_URL;
+
     static {
         // Initialize configuration with System properties, if available
         readConfiguration(null);
@@ -78,6 +88,9 @@ public class ServerConfiguration {
         ALLOW_IE_COMPRESSION = getConfigValue("echo.allowiecompression", initParameters, false);
         JAVASCRIPT_COMPRESSION_ENABLED = getConfigValue("echo.javascript.compression", initParameters, false);
         IE_EDGE_MODE = getConfigValue("echo.ie-edge-mode", initParameters, true);
+        NOSCRIPT_MESSAGE = getConfigValue("echo.noscript.message", initParameters, "This site only works with JavaScript " +
+                "enabled. Please enable JavaScript and reload the page. Hints how to enable JavaScript can be found at: ");
+        NOSCRIPT_URL = getConfigValue("echo.noscript.url", initParameters, "http://www.enable-javascript.com/");
     }
 
     /**

--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/resource/RemoteClient.js
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/resource/RemoteClient.js
@@ -149,6 +149,8 @@ Echo.RemoteClient = Core.extend(Echo.Client, {
      * @type Number
      */
     transactionId: 0,
+
+    _initialSyncComplete: false,
     
     /**
      * Creates a new RemoteClient instance.
@@ -481,6 +483,13 @@ Echo.RemoteClient = Core.extend(Echo.Client, {
         if (e.source.resync) {
             this.displayError(this.domainElement, this.configuration["Resync.Message"], null, 
                     this.configuration["Action.Continue"], null, Echo.Client.STYLE_MESSAGE);
+        }
+
+        if (!this._initialSyncComplete) {
+            if (this._isBrowserOutdated()) {
+                this._showBrowserWarning();
+            }
+            this._initialSyncComplete = true;
         }
     },
     

--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/service/WindowHtmlService.java
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/service/WindowHtmlService.java
@@ -182,7 +182,23 @@ implements Service {
         rootDivElement.setAttribute("style", "position:absolute;width:100%;height:100%;");
         rootDivElement.setAttribute("id", userInstanceContainer.getRootHtmlElementId());
         bodyElement.appendChild(rootDivElement);
-        
+
+        // Add a <noscript> element that shows up when JavaScript is disabled in the browser (and echo therefor
+        // does not work at all)
+        if (ServerConfiguration.NOSCRIPT_MESSAGE != null && !"".equals(ServerConfiguration.NOSCRIPT_MESSAGE)) {
+            Element jsDisabledDiv = document.createElement("noscript");
+            jsDisabledDiv.setTextContent(ServerConfiguration.NOSCRIPT_MESSAGE);
+            jsDisabledDiv.setAttribute("style", "padding: 10px; font-weight: bold; font-size: 14pt;");
+            bodyElement.appendChild(jsDisabledDiv);
+
+            if (ServerConfiguration.NOSCRIPT_URL != null && !"".equals(ServerConfiguration.NOSCRIPT_URL)) {
+                Element jsA = document.createElement("a");
+                jsA.setAttribute("href", ServerConfiguration.NOSCRIPT_URL);
+                jsA.setTextContent(ServerConfiguration.NOSCRIPT_URL);
+                jsDisabledDiv.appendChild(jsA);
+            }
+        }
+
         return document;
     }
     


### PR DESCRIPTION
- The Echo3 server-side implementation now adds a noscript-element
  with a warning that shows up when JavaScript is disabled in the user's browser.
  The text and link displayed can be customized in ServerConfiguration.
- A warning is shown at client startup when the detected browser version is considered outdated
  by the current Echo3 client-side implementation (detected in Echo.Client._isBrowserOutdated).
  The text of the default warning implementation Echo.Client.DefaultOutdatedBrowserWarning
  can be configured using new 'ClientConfiguration' properties or substituted
  by a new implementation analogous to WaitIndicator. An example implementation is included in
  the interactive test application. The warning can be disabled by setting the
  ClientConfiguration.OUTDATED_BROWSER_NO_WARNING flag.

Resolves #59
