### PR TITLE
 Configurable handling of invalid Ajax responses

### DIFF
--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/ClientConfiguration.java
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/ClientConfiguration.java
@@ -60,6 +60,21 @@ implements Serializable {
      * be restarted in the event session expires.  An alert message will not be shown if this value is set.
      */
     public static final String SESSION_EXPIRATION_RESTART = "SessionExpiration.Restart";
+
+    /**
+     * Property name constant for boolean flag indicating whether the application should automatically
+     * be restarted in the event a XMLHttpRequest response is invalid (non-2xx status codes, no XML in response).
+     * This can happen if for example a web access management agent or proxy intercepts the AJAX request and returns
+     * a login page instead.
+     * An alert message will not be shown if this value is set.
+     */
+    public static final String INVALID_RESPONSE_RESTART = "InvalidResponse.Restart";
+
+    /**
+     * Property name constant for the URI which should be displayed in the event
+     * a response is invalid. An alert message will not be shown if this value is set.
+     */
+    public static final String INVALID_RESPONSE_URI = "InvalidResponse.URI";
     
     /**
      * Property name constant for the alert message which should be displayed when

--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/resource/RemoteClient.js
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/resource/RemoteClient.js
@@ -318,6 +318,13 @@ Echo.RemoteClient = Core.extend(Echo.Client, {
                 this._handleSessionExpiration();
                 return;
             } else {
+                if (this.configuration["InvalidResponse.Restart"]) {
+                    window.location.reload();
+                    return;
+                } else if (this.configuration["InvalidResponse.URI"]) {
+                    window.location.href = this.configuration["InvalidResponse.URI"];
+                    return;
+                }
                 detail = e.source.getResponseText();
             }
         } else {


### PR DESCRIPTION
This feature introduces configurable handling of invalid Ajax responses returned
to the remote Echo client. This can happen if, for example, a web access management
agent intercepts the Echo synchronization Ajax request and returns a HTML login page
instead. This page would be displayed as HTML code in the Echo error window. With this patch,
the application can be configured to either restart immediately (thus forcing a GET request
that should lead to the login page) or to forward the browser to an arbitrary URI.
