### PR TITLE
Sync.Color bugfix

### DIFF
--- a/src/client/echo/Sync.js
+++ b/src/client/echo/Sync.js
@@ -440,7 +440,7 @@ Echo.Sync.Color = {
      * @param {String} styleAttribute the name of the style attribute, e.g., "color", "backgroundColor" 
      */
     renderClear: function(color, element, styleAttribute) {
-        element.style[styleAttribute] = color ? color : "";
+        element.style[styleAttribute] = color ? this.toTransparent(color) : "";
     },
     
     /**


### PR DESCRIPTION
renderClear(), contrary to render(), did not convert transparent colors (e.g. "#-1")
to valid CSS style values. This causes exceptions in IE8.
