### PR TITLE
WindowPane: Fix NPE in modal overlay handling when component is unregistered

### DIFF
--- a/src/client/echo/Sync.WindowPane.js
+++ b/src/client/echo/Sync.WindowPane.js
@@ -843,12 +843,12 @@ Echo.Sync.WindowPane = Core.extend(Echo.Render.ComponentSync, {
     },
 
     _handleModalChange: function(e) {
-        if (!e.modal || this.component.application.getModalContextRoot() != this.component) {
+        if (!e.modal || (this.component.application && this.component.application.getModalContextRoot() != this.component)) {
             if (this._modalOverlayDiv) {
                 this._modalOverlayDiv.parentNode.removeChild(this._modalOverlayDiv);
                 this._modalOverlayDiv = null;
             }
-        } else if (this.component.application.getModalContextRoot() == this.component && this._div && !this._modalOverlayDiv) {
+        } else if (this.component.application && this.component.application.getModalContextRoot() == this.component && this._div && !this._modalOverlayDiv) {
             this._modalOverlayDiv = Echo.Sync.WindowPane._prototypeModalOverlay.cloneNode(false);
             this._div.parentNode.insertBefore(this._modalOverlayDiv, this._div);
         }


### PR DESCRIPTION
When a window pane is unregistered, its application reference is set to null,
which was not checked for in the modal change callbacks later on.

The bug was confirmed and the fix tested in the scenario described in issue #77

Fixes #77
