### PR TITLE
Added textOverflow style property to Echo.Button JavaScript class

### DIFF
--- a/src/client/echo/Application.js
+++ b/src/client/echo/Application.js
@@ -2725,10 +2725,31 @@ Echo.AbstractButton = Core.extend(Echo.Component, {
 });
 
 /**
- * Button component: a stateless "push" button which is used to initiate an
- * action.  May not contain child components.
+ * Button component: a stateless "push" button which is used to initiate an action.  May not contain child components.
+ * @sp {Number} textOverflow a value indicating how the button will clip text if it has a defined width and isn't large enough for
+ *     its text, one of the following values:
+ *     <ul>
+ *     <li><code>TEXT_OVERFLOW_CLIP</code> (the default) clip the text without any indication</li>
+ *     <li><code>TEXT_OVERFLOW_ELLIPSIS</code> clip the text by appending an ellipsis ("...") to the visible portion</li>
+ *     </ul>
  */
 Echo.Button = Core.extend(Echo.AbstractButton, {
+
+    $static: {
+        /**
+         * Constant value for <code>textOverflow</code> property indicating that text that won't fit in the button's width will
+         * simply be clipped.  <code>TEXT_OVERFLOW_CLIP</code> is the default textOverflow setting.
+         * @type Number
+         */
+        TEXT_OVERFLOW_CLIP: 0,
+
+        /**
+         * Constant value for <code>textOverflow</code> property indicating that text that won't fit in the button's width will be
+         * represented by an ellipsis ("...").
+         * @type Number
+         */
+        TEXT_OVERFLOW_ELLIPSIS: 1
+    },
 
     $load: function() {
         Echo.ComponentFactory.registerType("Button", this);

--- a/src/client/echo/Sync.Button.js
+++ b/src/client/echo/Sync.Button.js
@@ -406,6 +406,16 @@ Echo.Sync.Button = Core.extend(Echo.Render.ComponentSync, {
         if (!this.component.render("lineWrap", true)) {
             element.style.whiteSpace = "nowrap";
         }
+        
+        var textOverflow = this.component.render("textOverflow", Echo.Button.TEXT_OVERFLOW_CLIP);
+        switch (textOverflow) {
+        case Echo.Button.TEXT_OVERFLOW_ELLIPSIS:
+            element.style.textOverflow = "ellipsis";
+            break;
+        case Echo.Button.TEXT_OVERFLOW_CLIP:
+            element.style.textOverflow = "clip";
+            break;
+        }
     },
     
     /** 


### PR DESCRIPTION
Added "textOverflow" style property to the JavaScript API's Echo.Button class. Can take one of two values (TEXT_OVERFLOW_CLIP or TEXT_OVERFLOW_ELLIPSIS) which determine how the button's text clips when the button has a defined width and the text won't all fit on it.
