### PR TITLE
Assume browser is supported when version cannot be detected

### DIFF
--- a/src/client/echo/Client.js
+++ b/src/client/echo/Client.js
@@ -324,6 +324,9 @@ Echo.Client = Core.extend({
       * @return true, if the browser is outdated - false, if the browser is unknown or supported.
       */
     _isBrowserOutdated: function() {
+        if (Core.Web.Env.BROWSER_VERSION_MAJOR === null) {
+            return false; // Unknown version, assume supported
+        }
         return (Core.Web.Env.ENGINE_MSHTML && Core.Web.Env.BROWSER_VERSION_MAJOR < 6); // IE < 6 is outdated
     },
 


### PR DESCRIPTION
Assume the browser is supported when the browser version cannot be determined
by Core.Web from the user agent string.

Fixes #88 - IE 11 is misdetected as outdated.
