### PR TITLE
Send scripts with mime type text/plain to support X-Content-Type-Options nosniff

### DIFF
--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/service/JavaScriptService.java
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/service/JavaScriptService.java
@@ -142,7 +142,7 @@ implements Service {
      */
     private void serviceGZipCompressed(Connection conn) 
     throws IOException {
-        conn.getResponse().setContentType("text/javascript");
+        conn.getResponse().setContentType("application/javascript");
         conn.getResponse().setHeader("Content-Encoding", "gzip");
         conn.getOutputStream().write(gzipContent);
     }
@@ -154,7 +154,7 @@ implements Service {
      */
     private void servicePlain(Connection conn) 
     throws IOException {
-        conn.getResponse().setContentType("text/javascript");
+        conn.getResponse().setContentType("application/javascript");
         conn.getWriter().print(content);
     }
 }

--- a/src/server-java/webcontainer/nextapp/echo/webcontainer/service/JavaScriptService.java
+++ b/src/server-java/webcontainer/nextapp/echo/webcontainer/service/JavaScriptService.java
@@ -142,7 +142,7 @@ implements Service {
      */
     private void serviceGZipCompressed(Connection conn) 
     throws IOException {
-        conn.getResponse().setContentType("text/plain");
+        conn.getResponse().setContentType("text/javascript");
         conn.getResponse().setHeader("Content-Encoding", "gzip");
         conn.getOutputStream().write(gzipContent);
     }
@@ -154,7 +154,7 @@ implements Service {
      */
     private void servicePlain(Connection conn) 
     throws IOException {
-        conn.getResponse().setContentType("text/plain");
+        conn.getResponse().setContentType("text/javascript");
         conn.getWriter().print(content);
     }
 }


### PR DESCRIPTION
If an echo3 application is proxied with apache with
`LoadModule headers_module /opt/inet/apache-2.4/modules/mod_headers.so
<ifModule mod_headers.c>
        Header set X-Content-Type-Options nosniff
</ifModule>`

browsers fail with a message:
`Refused to execute script from 'http://localhost:8080/test?sid=Echo.Boot' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.`

This pull request fixed that by sending scripts with mime type text/javascript.